### PR TITLE
Modelagem de Mass e API mínima de missas (create/list/detail)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,29 @@ Se já existir CERIMONIARIO, a rota retorna `409`.
 
 Ao logar com sucesso, a UI redireciona para `/masses`. Ao acessar `/login` já autenticado, há redirecionamento automático para `/masses`.
 
+Exemplo de login com persistência de cookie:
+
+```bash
+curl -i -c cookie.txt -X POST http://localhost:3000/api/login \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"admin","password":"SenhaForte123"}'
+```
+
+Resposta de sucesso (resumo):
+
+```json
+{
+  "ok": true,
+  "token": "<jwt>"
+}
+```
+
 ## Endpoints RBAC
 
 ### Health protegido (qualquer autenticado)
 
 ```bash
-curl -i http://localhost:3000/api/health/protected
+curl -i -b cookie.txt http://localhost:3000/api/health/protected
 ```
 
 Com cookie de sessão válido, retorna `200` com `user.id` e `user.role`.
@@ -63,7 +80,7 @@ Com cookie de sessão válido, retorna `200` com `user.id` e `user.role`.
 ### Health admin-only (somente CERIMONIARIO)
 
 ```bash
-curl -i http://localhost:3000/api/health/admin
+curl -i -b cookie.txt http://localhost:3000/api/health/admin
 ```
 
 - `200` para CERIMONIARIO
@@ -75,36 +92,100 @@ curl -i http://localhost:3000/api/health/admin
 ```bash
 curl -X POST http://localhost:3000/api/users \
   -H 'Content-Type: application/json' \
+  -b cookie.txt \
   -d '{"name":"Novo Acólito","username":"acolito1","password":"Senha123","role":"ACOLITO"}'
 ```
 
 Essa rota exige sessão válida de CERIMONIARIO.
 
+## API de Missas (etapa 2)
+
+### Criar missa (somente CERIMONIARIO)
+
+```bash
+curl -i -X POST http://localhost:3000/api/masses \
+  -H 'Content-Type: application/json' \
+  -b cookie.txt \
+  -d '{
+    "scheduledAt":"2026-02-14T19:00:00.000Z",
+    "assignments":[
+      {"roleKey":"CRUZ", "userId": null},
+      {"roleKey":"VELA_1", "userId": null}
+    ]
+  }'
+```
+
+Resposta de sucesso:
+
+```json
+{
+  "massId": "67aa53c8f93f5fa8d8f64cd2"
+}
+```
+
+### Listar missas (autenticado)
+
+```bash
+curl -i -b cookie.txt 'http://localhost:3000/api/masses?status=SCHEDULED&from=2026-02-01T00:00:00.000Z&to=2026-02-28T23:59:59.999Z'
+```
+
+Resposta de sucesso:
+
+```json
+{
+  "items": [
+    {
+      "id": "67aa53c8f93f5fa8d8f64cd2",
+      "status": "SCHEDULED",
+      "scheduledAt": "2026-02-14T19:00:00.000Z",
+      "chiefBy": "67aa5000f93f5fa8d8f64ca1",
+      "createdBy": "67aa5000f93f5fa8d8f64ca1"
+    }
+  ]
+}
+```
+
+### Detalhar missa por id (autenticado)
+
+```bash
+curl -i -b cookie.txt http://localhost:3000/api/masses/67aa53c8f93f5fa8d8f64cd2
+```
+
+Resposta de sucesso (resumo):
+
+```json
+{
+  "id": "67aa53c8f93f5fa8d8f64cd2",
+  "status": "SCHEDULED",
+  "scheduledAt": "2026-02-14T19:00:00.000Z",
+  "createdBy": "67aa5000f93f5fa8d8f64ca1",
+  "chiefBy": "67aa5000f93f5fa8d8f64ca1",
+  "attendance": {
+    "joined": [],
+    "confirmed": []
+  },
+  "assignments": [
+    { "roleKey": "CRUZ", "userId": null }
+  ],
+  "events": []
+}
+```
+
+## Seed opcional de missa
+
+```bash
+npm run seed:mass
+```
+
+O comando busca o primeiro `CERIMONIARIO` ativo e cria uma missa para `+2 dias` (arredondada para a hora cheia). É idempotente com tolerância de ±5 minutos no `scheduledAt`.
+
 ## Teste manual ponta a ponta (com cookies)
 
 1. Bootstrap do admin em `/api/setup`.
-2. Login do admin em `/api/login` salvando cookie:
-
-```bash
-curl -i -c cookie.txt -X POST http://localhost:3000/api/login \
-  -H 'Content-Type: application/json' \
-  -d '{"username":"admin","password":"SenhaForte123"}'
-```
-
-3. Criar usuário com sessão do admin:
-
-```bash
-curl -i -b cookie.txt -X POST http://localhost:3000/api/users \
-  -H 'Content-Type: application/json' \
-  -d '{"name":"Acolito","username":"acolito","password":"Senha123","role":"ACOLITO"}'
-```
-
-4. Validar endpoints protegidos:
-
-```bash
-curl -i -b cookie.txt http://localhost:3000/api/health/protected
-curl -i -b cookie.txt http://localhost:3000/api/health/admin
-```
+2. Login do admin em `/api/login` salvando cookie em `cookie.txt`.
+3. Criar uma missa em `/api/masses`.
+4. Listar missas em `/api/masses`.
+5. Ver detalhe em `/api/masses/:id`.
 
 ## Decisão sobre signup público
 

--- a/app/api/masses/[id]/route.ts
+++ b/app/api/masses/[id]/route.ts
@@ -1,0 +1,75 @@
+import { NextResponse } from "next/server";
+
+import dbConnect from "@/lib/db";
+import { requireAuth } from "@/lib/auth";
+import { getMassModel } from "@/models/Mass";
+import { getMongoose } from "@/lib/mongoose";
+
+export const runtime = "nodejs";
+
+type RouteContext = {
+  params: Promise<{ id: string }>;
+};
+
+export async function GET(req: Request, context: RouteContext) {
+  try {
+    await requireAuth(req);
+    await dbConnect();
+
+    const { id } = await context.params;
+    const mongoose = getMongoose();
+
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return NextResponse.json({ error: "id inválido" }, { status: 400 });
+    }
+
+    const mass = await getMassModel().findById(id).lean();
+
+    if (!mass) {
+      return NextResponse.json({ error: "Missa não encontrada" }, { status: 404 });
+    }
+
+    return NextResponse.json({
+      id: mass._id.toString(),
+      status: mass.status,
+      scheduledAt: mass.scheduledAt,
+      createdBy: mass.createdBy.toString(),
+      chiefBy: mass.chiefBy.toString(),
+      openedAt: mass.openedAt ?? null,
+      preparationAt: mass.preparationAt ?? null,
+      finishedAt: mass.finishedAt ?? null,
+      canceledAt: mass.canceledAt ?? null,
+      attendance: {
+        joined: mass.attendance?.joined?.map((entry) => ({
+          userId: entry.userId.toString(),
+          joinedAt: entry.joinedAt,
+        })) ?? [],
+        confirmed: mass.attendance?.confirmed?.map((entry) => ({
+          userId: entry.userId.toString(),
+          confirmedAt: entry.confirmedAt,
+        })) ?? [],
+      },
+      assignments:
+        mass.assignments?.map((assignment) => ({
+          roleKey: assignment.roleKey,
+          userId: assignment.userId ? assignment.userId.toString() : null,
+        })) ?? [],
+      events:
+        mass.events?.map((event) => ({
+          type: event.type,
+          actorId: event.actorId.toString(),
+          at: event.at,
+          payload: event.payload ?? null,
+        })) ?? [],
+      createdAt: mass.createdAt,
+      updatedAt: mass.updatedAt,
+    });
+  } catch (error) {
+    if (error instanceof Error && error.message === "Não autorizado") {
+      return NextResponse.json({ error: error.message }, { status: 401 });
+    }
+
+    console.error("Erro ao detalhar missa:", error);
+    return NextResponse.json({ error: "Erro no servidor" }, { status: 500 });
+  }
+}

--- a/app/api/masses/route.ts
+++ b/app/api/masses/route.ts
@@ -1,0 +1,165 @@
+import { NextResponse } from "next/server";
+
+import dbConnect from "@/lib/db";
+import { requireAuth, requireCerimoniario } from "@/lib/auth";
+import { MASS_STATUSES, type MassStatus, getMassModel } from "@/models/Mass";
+import { getMongoose } from "@/lib/mongoose";
+import { getUserModel } from "@/models/User";
+
+export const runtime = "nodejs";
+
+const isValidDate = (value: string): boolean => !Number.isNaN(new Date(value).getTime());
+const isMassStatus = (value: unknown): value is MassStatus =>
+  typeof value === "string" && MASS_STATUSES.includes(value as MassStatus);
+
+export async function POST(req: Request) {
+  try {
+    const auth = await requireCerimoniario(req);
+    await dbConnect();
+
+    const body = (await req.json()) as {
+      scheduledAt?: string;
+      chiefBy?: string;
+      assignments?: Array<{ roleKey?: unknown; userId?: unknown }>;
+    };
+
+    if (!body.scheduledAt || !isValidDate(body.scheduledAt)) {
+      return NextResponse.json({ error: "scheduledAt inválido" }, { status: 400 });
+    }
+
+    const mongoose = getMongoose();
+    const createdBy = new mongoose.Types.ObjectId(auth.userId);
+
+    let chiefBy = createdBy;
+    if (typeof body.chiefBy === "string") {
+      if (!mongoose.Types.ObjectId.isValid(body.chiefBy)) {
+        return NextResponse.json({ error: "chiefBy inválido" }, { status: 400 });
+      }
+
+      const chiefUser = await getUserModel()
+        .findOne({ _id: body.chiefBy, role: "CERIMONIARIO", active: true })
+        .select("_id")
+        .lean();
+
+      if (!chiefUser) {
+        return NextResponse.json({ error: "chiefBy deve ser um CERIMONIARIO ativo" }, { status: 400 });
+      }
+
+      chiefBy = new mongoose.Types.ObjectId(body.chiefBy);
+    }
+
+    const assignments =
+      body.assignments?.map((assignment) => {
+        const roleKey = typeof assignment.roleKey === "string" ? assignment.roleKey.trim() : "";
+
+        if (!roleKey) {
+          throw new Error("roleKey inválido");
+        }
+
+        const userIdRaw = assignment.userId;
+        if (userIdRaw === null || userIdRaw === undefined) {
+          return { roleKey, userId: null };
+        }
+
+        if (typeof userIdRaw !== "string" || !mongoose.Types.ObjectId.isValid(userIdRaw)) {
+          throw new Error("userId inválido em assignments");
+        }
+
+        return { roleKey, userId: new mongoose.Types.ObjectId(userIdRaw) };
+      }) ?? [];
+
+    const mass = await getMassModel().create({
+      scheduledAt: new Date(body.scheduledAt),
+      createdBy,
+      chiefBy,
+      assignments,
+    });
+
+    return NextResponse.json({ massId: mass._id.toString() }, { status: 201 });
+  } catch (error) {
+    if (error instanceof Error) {
+      if (error.message === "Não autorizado") {
+        return NextResponse.json({ error: error.message }, { status: 401 });
+      }
+
+      if (error.message === "Acesso negado") {
+        return NextResponse.json({ error: error.message }, { status: 403 });
+      }
+
+      if (error.message === "roleKey inválido" || error.message === "userId inválido em assignments") {
+        return NextResponse.json({ error: error.message }, { status: 400 });
+      }
+    }
+
+    console.error("Erro ao criar missa:", error);
+    return NextResponse.json({ error: "Erro no servidor" }, { status: 500 });
+  }
+}
+
+export async function GET(req: Request) {
+  try {
+    await requireAuth(req);
+    await dbConnect();
+
+    const { searchParams } = new URL(req.url);
+    const statusParam = searchParams.get("status");
+    const fromParam = searchParams.get("from");
+    const toParam = searchParams.get("to");
+
+    const filter: {
+      status?: MassStatus;
+      scheduledAt?: {
+        $gte?: Date;
+        $lte?: Date;
+      };
+    } = {};
+
+    if (statusParam) {
+      if (!isMassStatus(statusParam)) {
+        return NextResponse.json({ error: "status inválido" }, { status: 400 });
+      }
+      filter.status = statusParam;
+    }
+
+    if (fromParam || toParam) {
+      filter.scheduledAt = {};
+
+      if (fromParam) {
+        if (!isValidDate(fromParam)) {
+          return NextResponse.json({ error: "from inválido" }, { status: 400 });
+        }
+        filter.scheduledAt.$gte = new Date(fromParam);
+      }
+
+      if (toParam) {
+        if (!isValidDate(toParam)) {
+          return NextResponse.json({ error: "to inválido" }, { status: 400 });
+        }
+        filter.scheduledAt.$lte = new Date(toParam);
+      }
+    }
+
+    const masses = await getMassModel()
+      .find(filter)
+      .sort({ scheduledAt: 1 })
+      .select("_id status scheduledAt chiefBy createdBy")
+      .lean();
+
+    return NextResponse.json({
+      items: masses.map((mass) => ({
+        id: mass._id.toString(),
+        status: mass.status,
+        scheduledAt: mass.scheduledAt,
+        chiefBy: mass.chiefBy?.toString(),
+        createdBy: mass.createdBy?.toString(),
+      })),
+    });
+  } catch (error) {
+    if (error instanceof Error && error.message === "Não autorizado") {
+      return NextResponse.json({ error: error.message }, { status: 401 });
+    }
+
+    console.error("Erro ao listar missas:", error);
+    return NextResponse.json({ error: "Erro no servidor" }, { status: 500 });
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "seed:mass": "node scripts/seed-mass.js"
   },
   "dependencies": {
     "@radix-ui/react-context-menu": "^2.2.2",

--- a/scripts/seed-mass.js
+++ b/scripts/seed-mass.js
@@ -1,0 +1,77 @@
+/* eslint-disable no-console */
+const mongoose = require("mongoose");
+const { loadEnvConfig } = require("@next/env");
+
+loadEnvConfig(process.cwd());
+
+const uri = process.env.MONGODB_URI;
+if (!uri) {
+  throw new Error("Defina MONGODB_URI no .env.local");
+}
+
+const userSchema = new mongoose.Schema(
+  {
+    role: { type: String, required: true },
+    active: { type: Boolean, required: true },
+  },
+  { collection: "users" }
+);
+
+const massSchema = new mongoose.Schema(
+  {
+    status: String,
+    scheduledAt: Date,
+    createdBy: mongoose.Types.ObjectId,
+    chiefBy: mongoose.Types.ObjectId,
+  },
+  { collection: "masses", timestamps: true }
+);
+
+const User = mongoose.models.SeedUser || mongoose.model("SeedUser", userSchema);
+const Mass = mongoose.models.SeedMass || mongoose.model("SeedMass", massSchema);
+
+const buildTargetDate = () => {
+  const date = new Date();
+  date.setDate(date.getDate() + 2);
+  date.setMinutes(0, 0, 0);
+  return date;
+};
+
+async function run() {
+  await mongoose.connect(uri);
+
+  const cerimoniario = await User.findOne({ role: "CERIMONIARIO", active: true }).select("_id").lean();
+  if (!cerimoniario) {
+    console.log("Nenhum CERIMONIARIO ativo encontrado. Nada para seed.");
+    return;
+  }
+
+  const target = buildTargetDate();
+  const toleranceMs = 5 * 60 * 1000;
+  const from = new Date(target.getTime() - toleranceMs);
+  const to = new Date(target.getTime() + toleranceMs);
+
+  const existing = await Mass.findOne({ scheduledAt: { $gte: from, $lte: to } }).select("_id scheduledAt").lean();
+  if (existing) {
+    console.log(`Missa já existe próximo desse horário: ${existing._id} (${existing.scheduledAt.toISOString()})`);
+    return;
+  }
+
+  const created = await Mass.create({
+    status: "SCHEDULED",
+    scheduledAt: target,
+    createdBy: cerimoniario._id,
+    chiefBy: cerimoniario._id,
+  });
+
+  console.log(`Missa criada: ${created._id.toString()} em ${target.toISOString()}`);
+}
+
+run()
+  .catch((error) => {
+    console.error("Falha no seed de missa:", error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await mongoose.disconnect();
+  });


### PR DESCRIPTION
### Motivation
- Implementar a segunda etapa da feature de Missa oferecendo a modelagem completa e os endpoints mínimos para criação e leitura.
- Reutilizar o padrão existente de conexão Mongoose/TypeScript e o helper de autenticação (`getAuth`/`requireAuth`) com RBAC por `role`.
- Manter rotas no App Router (`app/api`) e evitar Edge runtime em handlers que acessam MongoDB.

### Description
- Adicionado/atualizado o modelo `Mass` em `models/Mass.ts` com campos exigidos, subdocumentos para `attendance`, `assignments` e `events`, enum de `status` e `timestamps`, além de proteção contra recompilação com `mongoose.models.Mass || mongoose.model(...)`.
- Criados índices em schema de `Mass` para `{ status, scheduledAt }`, `{ scheduledAt }`, `{ createdBy }` e `{ chiefBy }` para suportar consultas eficientes.
- Implementados endpoints no App Router: `POST /api/masses` (cria missa, exige `CERIMONIARIO`, valida `scheduledAt` e `chiefBy`, aceita `assignments`) e `GET /api/masses` (lista enxuta com filtros `status/from/to`), ambos em `app/api/masses/route.ts`, e `GET /api/masses/:id` (detalhe completo) em `app/api/masses/[id]/route.ts`, todos com `export const runtime = "nodejs"`.
- Adicionado script de seed idempotente `scripts/seed-mass.js` e comando `npm run seed:mass`, e atualizada documentação `README.md` com variáveis de ambiente e exemplos `curl` para login, criação, listagem, detalhe e seed.

### Testing
- Executei `npm run lint` e a checagem de ESLint passou com sucesso (`✔ No ESLint warnings or errors`).
- Executei `npm run build` e o build foi concluído com sucesso; o processo exibiu avisos de tentativa de patch no lockfile/SWC por limitação de rede, mas não impediu a finalização do build.
- Verifiquei o script de seed com `node --check scripts/seed-mass.js` sem erros.
- O conjunto de alterações foi commitado e está pronto para revisão (arquivos alterados: `README.md`, `models/Mass.ts`, `app/api/masses/route.ts`, `app/api/masses/[id]/route.ts`, `package.json`, `scripts/seed-mass.js`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b87b21294832ca4e6512e36778457)