### PR TITLE
Etapa 4: hardening operacional — requestId, erros padronizados, rate-limit e endpoints de operação

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,41 +1,46 @@
-import { NextResponse } from "next/server";
 import bcrypt from "bcrypt";
 
 import dbConnect from "@/lib/db";
 import { createSessionToken, sessionCookieOptions } from "@/lib/auth";
 import { getUserModel } from "@/models/User";
+import { ApiError, toHttpResponse } from "@/src/server/http/errors";
+import { getClientIp, getRequestId } from "@/src/server/http/request";
+import { jsonOk } from "@/src/server/http/response";
+import { assertLoginRateLimit } from "@/src/server/security/rate-limit";
+import { logError, logInfo } from "@/src/server/http/logging";
 
 export const runtime = "nodejs";
 
 export async function POST(req: Request) {
+  const requestId = getRequestId(req);
+
   try {
+    assertLoginRateLimit(getClientIp(req));
+
     const body = (await req.json()) as { username?: string; password?: string };
     const username = typeof body.username === "string" ? body.username.trim().toLowerCase() : "";
     const password = typeof body.password === "string" ? body.password : "";
 
     if (!username || !password) {
-      return NextResponse.json({ error: "Dados inválidos" }, { status: 400 });
+      throw new ApiError({ code: "VALIDATION_ERROR", message: "Dados inválidos", status: 400 });
     }
 
     await dbConnect();
 
-    const user = await getUserModel()
-      .findOne({ username })
-      .select("_id passwordHash role active")
-      .lean();
+    const user = await getUserModel().findOne({ username }).select("_id passwordHash role active").lean();
 
     if (!user || !user.active) {
-      return NextResponse.json({ error: "Usuário ou senha incorretos" }, { status: 401 });
+      throw new ApiError({ code: "UNAUTHENTICATED", message: "Usuário ou senha incorretos", status: 401 });
     }
 
     const passwordMatch = await bcrypt.compare(password, user.passwordHash);
     if (!passwordMatch) {
-      return NextResponse.json({ error: "Usuário ou senha incorretos" }, { status: 401 });
+      throw new ApiError({ code: "UNAUTHENTICATED", message: "Usuário ou senha incorretos", status: 401 });
     }
 
     const token = await createSessionToken({ userId: user._id.toString(), role: user.role });
 
-    const response = NextResponse.json({ ok: true, token });
+    const response = jsonOk({ ok: true, token }, requestId);
     response.cookies.set(sessionCookieOptions.name, token, {
       httpOnly: sessionCookieOptions.httpOnly,
       maxAge: sessionCookieOptions.maxAge,
@@ -44,9 +49,10 @@ export async function POST(req: Request) {
       secure: sessionCookieOptions.secure,
     });
 
+    logInfo(requestId, "User logged in", { userId: user._id.toString(), role: user.role });
     return response;
   } catch (error) {
-    console.error("Erro no servidor:", error);
-    return NextResponse.json({ error: "Erro no servidor" }, { status: 500 });
+    logError(requestId, "Erro no login", error);
+    return toHttpResponse(error, requestId);
   }
 }

--- a/app/api/auth/me/route.ts
+++ b/app/api/auth/me/route.ts
@@ -1,16 +1,23 @@
-import { NextResponse } from "next/server";
-
 import { getAuth } from "@/lib/auth";
+import { ApiError, toHttpResponse } from "@/src/server/http/errors";
+import { getRequestId } from "@/src/server/http/request";
+import { jsonOk } from "@/src/server/http/response";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export async function GET(req: Request) {
-  const auth = await getAuth(req);
+  const requestId = getRequestId(req);
 
-  if (!auth) {
-    return NextResponse.json({ authenticated: false }, { status: 401 });
+  try {
+    const auth = await getAuth(req);
+
+    if (!auth) {
+      throw new ApiError({ code: "UNAUTHENTICATED", message: "Não autorizado", status: 401 });
+    }
+
+    return jsonOk({ authenticated: true, user: { id: auth.userId, role: auth.role } }, requestId);
+  } catch (error) {
+    return toHttpResponse(error, requestId);
   }
-
-  return NextResponse.json({ authenticated: true, user: { id: auth.userId, role: auth.role } });
 }

--- a/app/api/health/admin/route.ts
+++ b/app/api/health/admin/route.ts
@@ -1,19 +1,18 @@
-import { NextResponse } from "next/server";
-
 import { requireCerimoniario } from "@/lib/auth";
+import { getRequestId } from "@/src/server/http/request";
+import { jsonOk } from "@/src/server/http/response";
+import { toHttpResponse } from "@/src/server/http/errors";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export async function GET(req: Request) {
+  const requestId = getRequestId(req);
+
   try {
     const user = await requireCerimoniario(req);
-    return NextResponse.json({ ok: true, user: { id: user.userId, role: user.role } });
+    return jsonOk({ ok: true, user: { id: user.userId, role: user.role } }, requestId);
   } catch (error) {
-    if (error instanceof Error && error.message === "Acesso negado") {
-      return NextResponse.json({ error: "Acesso negado" }, { status: 403 });
-    }
-
-    return NextResponse.json({ error: "Não autorizado" }, { status: 401 });
+    return toHttpResponse(error, requestId);
   }
 }

--- a/app/api/health/protected/route.ts
+++ b/app/api/health/protected/route.ts
@@ -1,15 +1,18 @@
-import { NextResponse } from "next/server";
-
 import { requireAuth } from "@/lib/auth";
+import { getRequestId } from "@/src/server/http/request";
+import { jsonOk } from "@/src/server/http/response";
+import { toHttpResponse } from "@/src/server/http/errors";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export async function GET(req: Request) {
+  const requestId = getRequestId(req);
+
   try {
     const user = await requireAuth(req);
-    return NextResponse.json({ ok: true, user: { id: user.userId, role: user.role } });
-  } catch {
-    return NextResponse.json({ error: "Não autorizado" }, { status: 401 });
+    return jsonOk({ ok: true, user: { id: user.userId, role: user.role } }, requestId);
+  } catch (error) {
+    return toHttpResponse(error, requestId);
   }
 }

--- a/app/api/login/route.ts
+++ b/app/api/login/route.ts
@@ -1,14 +1,22 @@
-import { NextResponse } from "next/server";
 import bcrypt from "bcrypt";
 
 import dbConnect from "@/lib/db";
 import { createSessionToken, sessionCookieOptions } from "@/lib/auth";
 import { getUserModel } from "@/models/User";
+import { ApiError, toHttpResponse } from "@/src/server/http/errors";
+import { getClientIp, getRequestId } from "@/src/server/http/request";
+import { jsonOk } from "@/src/server/http/response";
+import { assertLoginRateLimit } from "@/src/server/security/rate-limit";
+import { logError, logInfo } from "@/src/server/http/logging";
 
 export const runtime = "nodejs";
 
 export async function POST(req: Request) {
+  const requestId = getRequestId(req);
+
   try {
+    assertLoginRateLimit(getClientIp(req));
+
     const body = (await req.json()) as { username?: string; email?: string; password?: string };
     const usernameValue =
       typeof body.username === "string"
@@ -19,32 +27,25 @@ export async function POST(req: Request) {
     const password = typeof body.password === "string" ? body.password : "";
 
     if (!usernameValue || !password) {
-      return NextResponse.json({ error: "Dados inválidos" }, { status: 400 });
+      throw new ApiError({ code: "VALIDATION_ERROR", message: "Dados inválidos", status: 400 });
     }
 
     await dbConnect();
 
-    const user = await getUserModel()
-      .findOne({ username: usernameValue })
-      .select("_id passwordHash role active")
-      .lean();
+    const user = await getUserModel().findOne({ username: usernameValue }).select("_id passwordHash role active").lean();
 
     if (!user || !user.active) {
-      return NextResponse.json({ error: "Usuário ou senha incorretos" }, { status: 401 });
+      throw new ApiError({ code: "UNAUTHENTICATED", message: "Usuário ou senha incorretos", status: 401 });
     }
 
     const passwordMatch = await bcrypt.compare(password, user.passwordHash);
-
     if (!passwordMatch) {
-      return NextResponse.json({ error: "Usuário ou senha incorretos" }, { status: 401 });
+      throw new ApiError({ code: "UNAUTHENTICATED", message: "Usuário ou senha incorretos", status: 401 });
     }
 
-    const token = await createSessionToken({
-      userId: user._id.toString(),
-      role: user.role,
-    });
+    const token = await createSessionToken({ userId: user._id.toString(), role: user.role });
 
-    const response = NextResponse.json({ ok: true });
+    const response = jsonOk({ ok: true }, requestId);
     response.cookies.set(sessionCookieOptions.name, token, {
       httpOnly: sessionCookieOptions.httpOnly,
       maxAge: sessionCookieOptions.maxAge,
@@ -53,9 +54,10 @@ export async function POST(req: Request) {
       secure: sessionCookieOptions.secure,
     });
 
+    logInfo(requestId, "User logged in", { userId: user._id.toString(), role: user.role });
     return response;
   } catch (error) {
-    console.error("Erro no servidor:", error);
-    return NextResponse.json({ error: "Erro no servidor" }, { status: 500 });
+    logError(requestId, "Erro no login", error);
+    return toHttpResponse(error, requestId);
   }
 }

--- a/app/api/masses/[id]/delegate/route.ts
+++ b/app/api/masses/[id]/delegate/route.ts
@@ -1,47 +1,46 @@
-import { NextResponse } from "next/server";
-
 import dbConnect from "@/lib/db";
 import { requireAuth } from "@/lib/auth";
 import { getMongoose } from "@/lib/mongoose";
 import { getUserModel } from "@/models/User";
 import { delegateMassAction } from "@/src/domain/mass/actions";
-import { toErrorResponse, ValidationError } from "@/src/domain/mass/errors";
 import { serializeMass } from "@/src/domain/mass/serializers";
+import { ApiError, toHttpResponse } from "@/src/server/http/errors";
+import { getRequestId } from "@/src/server/http/request";
+import { jsonOk } from "@/src/server/http/response";
+import { logError, logInfo } from "@/src/server/http/logging";
 
 export const runtime = "nodejs";
 
 export async function POST(req: Request, context: { params: Promise<{ id: string }> }) {
+  const requestId = getRequestId(req);
+
   try {
     const actor = await requireAuth(req);
     await dbConnect();
 
     const body = (await req.json()) as { newChiefBy?: unknown };
     if (typeof body.newChiefBy !== "string" || !body.newChiefBy.trim()) {
-      throw new ValidationError("newChiefBy é obrigatório");
+      throw new ApiError({ code: "VALIDATION_ERROR", message: "newChiefBy é obrigatório", status: 400 });
     }
 
     const newChiefBy = body.newChiefBy.trim();
     const mongoose = getMongoose();
     if (!mongoose.Types.ObjectId.isValid(newChiefBy)) {
-      throw new ValidationError("newChiefBy inválido");
+      throw new ApiError({ code: "VALIDATION_ERROR", message: "newChiefBy inválido", status: 400 });
     }
 
     const chiefUser = await getUserModel().findOne({ _id: newChiefBy, role: "CERIMONIARIO", active: true }).select("_id").lean();
     if (!chiefUser) {
-      throw new ValidationError("newChiefBy deve ser um CERIMONIARIO ativo");
+      throw new ApiError({ code: "VALIDATION_ERROR", message: "newChiefBy deve ser um CERIMONIARIO ativo", status: 400 });
     }
 
     const { id: massId } = await context.params;
     const mass = await delegateMassAction({ massId, actor, newChiefBy });
+    logInfo(requestId, "Mass delegated", { massId });
 
-    return NextResponse.json({ ok: true, mass: serializeMass(mass) });
+    return jsonOk({ ok: true, mass: serializeMass(mass) }, requestId);
   } catch (error) {
-    const mapped = toErrorResponse(error);
-    if (mapped) {
-      return NextResponse.json({ error: mapped.message }, { status: mapped.status });
-    }
-
-    console.error("Erro ao delegar missa:", error);
-    return NextResponse.json({ error: "Erro no servidor" }, { status: 500 });
+    logError(requestId, "Erro ao delegar missa", error);
+    return toHttpResponse(error, requestId);
   }
 }

--- a/app/api/masses/[id]/route.ts
+++ b/app/api/masses/[id]/route.ts
@@ -1,9 +1,11 @@
-import { NextResponse } from "next/server";
-
 import dbConnect from "@/lib/db";
 import { requireAuth } from "@/lib/auth";
 import { getMassModel } from "@/models/Mass";
 import { getMongoose } from "@/lib/mongoose";
+import { ApiError, toHttpResponse } from "@/src/server/http/errors";
+import { jsonOk } from "@/src/server/http/response";
+import { getRequestId } from "@/src/server/http/request";
+import { logError } from "@/src/server/http/logging";
 
 export const runtime = "nodejs";
 
@@ -12,6 +14,8 @@ type RouteContext = {
 };
 
 export async function GET(req: Request, context: RouteContext) {
+  const requestId = getRequestId(req);
+
   try {
     await requireAuth(req);
     await dbConnect();
@@ -20,56 +24,56 @@ export async function GET(req: Request, context: RouteContext) {
     const mongoose = getMongoose();
 
     if (!mongoose.Types.ObjectId.isValid(id)) {
-      return NextResponse.json({ error: "id inválido" }, { status: 400 });
+      throw new ApiError({ code: "VALIDATION_ERROR", message: "id inválido", status: 400 });
     }
 
     const mass = await getMassModel().findById(id).lean();
-
     if (!mass) {
-      return NextResponse.json({ error: "Missa não encontrada" }, { status: 404 });
+      throw new ApiError({ code: "NOT_FOUND", message: "Missa não encontrada", status: 404 });
     }
 
-    return NextResponse.json({
-      id: mass._id.toString(),
-      status: mass.status,
-      scheduledAt: mass.scheduledAt,
-      createdBy: mass.createdBy.toString(),
-      chiefBy: mass.chiefBy.toString(),
-      openedAt: mass.openedAt ?? null,
-      preparationAt: mass.preparationAt ?? null,
-      finishedAt: mass.finishedAt ?? null,
-      canceledAt: mass.canceledAt ?? null,
-      attendance: {
-        joined: mass.attendance?.joined?.map((entry) => ({
-          userId: entry.userId.toString(),
-          joinedAt: entry.joinedAt,
-        })) ?? [],
-        confirmed: mass.attendance?.confirmed?.map((entry) => ({
-          userId: entry.userId.toString(),
-          confirmedAt: entry.confirmedAt,
-        })) ?? [],
+    return jsonOk(
+      {
+        id: mass._id.toString(),
+        status: mass.status,
+        scheduledAt: mass.scheduledAt,
+        createdBy: mass.createdBy.toString(),
+        chiefBy: mass.chiefBy.toString(),
+        openedAt: mass.openedAt ?? null,
+        preparationAt: mass.preparationAt ?? null,
+        finishedAt: mass.finishedAt ?? null,
+        canceledAt: mass.canceledAt ?? null,
+        attendance: {
+          joined:
+            mass.attendance?.joined?.map((entry) => ({
+              userId: entry.userId.toString(),
+              joinedAt: entry.joinedAt,
+            })) ?? [],
+          confirmed:
+            mass.attendance?.confirmed?.map((entry) => ({
+              userId: entry.userId.toString(),
+              confirmedAt: entry.confirmedAt,
+            })) ?? [],
+        },
+        assignments:
+          mass.assignments?.map((assignment) => ({
+            roleKey: assignment.roleKey,
+            userId: assignment.userId ? assignment.userId.toString() : null,
+          })) ?? [],
+        events:
+          mass.events?.map((event) => ({
+            type: event.type,
+            actorId: event.actorId.toString(),
+            at: event.at,
+            payload: event.payload ?? null,
+          })) ?? [],
+        createdAt: mass.createdAt,
+        updatedAt: mass.updatedAt,
       },
-      assignments:
-        mass.assignments?.map((assignment) => ({
-          roleKey: assignment.roleKey,
-          userId: assignment.userId ? assignment.userId.toString() : null,
-        })) ?? [],
-      events:
-        mass.events?.map((event) => ({
-          type: event.type,
-          actorId: event.actorId.toString(),
-          at: event.at,
-          payload: event.payload ?? null,
-        })) ?? [],
-      createdAt: mass.createdAt,
-      updatedAt: mass.updatedAt,
-    });
+      requestId
+    );
   } catch (error) {
-    if (error instanceof Error && error.message === "Não autorizado") {
-      return NextResponse.json({ error: error.message }, { status: 401 });
-    }
-
-    console.error("Erro ao detalhar missa:", error);
-    return NextResponse.json({ error: "Erro no servidor" }, { status: 500 });
+    logError(requestId, "Erro ao detalhar missa", error);
+    return toHttpResponse(error, requestId);
   }
 }

--- a/app/api/masses/mine/route.ts
+++ b/app/api/masses/mine/route.ts
@@ -1,0 +1,91 @@
+import dbConnect from "@/lib/db";
+import { requireAuth } from "@/lib/auth";
+import { MASS_STATUSES, type MassStatus, getMassModel } from "@/models/Mass";
+import { ApiError, toHttpResponse } from "@/src/server/http/errors";
+import { getRequestId } from "@/src/server/http/request";
+import { jsonOk } from "@/src/server/http/response";
+import { logError } from "@/src/server/http/logging";
+
+export const runtime = "nodejs";
+
+const isMassStatus = (value: unknown): value is MassStatus =>
+  typeof value === "string" && MASS_STATUSES.includes(value as MassStatus);
+
+const parseDate = (value: string | null, field: string): Date | null => {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw new ApiError({ code: "VALIDATION_ERROR", message: `${field} inválido`, status: 400 });
+  }
+  return date;
+};
+
+export async function GET(req: Request) {
+  const requestId = getRequestId(req);
+
+  try {
+    const auth = await requireAuth(req);
+    await dbConnect();
+
+    const { searchParams } = new URL(req.url);
+    const status = searchParams.get("status");
+    const from = parseDate(searchParams.get("from"), "from");
+    const to = parseDate(searchParams.get("to"), "to");
+
+    const page = Number(searchParams.get("page") || "1");
+    const limit = Math.min(Math.max(Number(searchParams.get("limit") || "20"), 1), 100);
+
+    if (!Number.isInteger(page) || page < 1) {
+      throw new ApiError({ code: "VALIDATION_ERROR", message: "page inválido", status: 400 });
+    }
+
+    const filter: Record<string, unknown> = {};
+    if (status) {
+      if (!isMassStatus(status)) {
+        throw new ApiError({ code: "VALIDATION_ERROR", message: "status inválido", status: 400 });
+      }
+      filter.status = status;
+    }
+
+    if (from || to) {
+      filter.scheduledAt = {
+        ...(from ? { $gte: from } : {}),
+        ...(to ? { $lte: to } : {}),
+      };
+    }
+
+    if (auth.role === "CERIMONIARIO") {
+      filter.$or = [{ createdBy: auth.userId }, { chiefBy: auth.userId }];
+    } else {
+      filter.$or = [{ "attendance.joined.userId": auth.userId }, { "attendance.confirmed.userId": auth.userId }];
+    }
+
+    const skip = (page - 1) * limit;
+
+    const masses = await getMassModel()
+      .find(filter)
+      .sort({ scheduledAt: 1 })
+      .skip(skip)
+      .limit(limit)
+      .select("_id status scheduledAt chiefBy createdBy")
+      .lean();
+
+    return jsonOk(
+      {
+        items: masses.map((mass) => ({
+          id: mass._id.toString(),
+          status: mass.status,
+          scheduledAt: mass.scheduledAt,
+          chiefBy: mass.chiefBy.toString(),
+          createdBy: mass.createdBy.toString(),
+        })),
+        page,
+        limit,
+      },
+      requestId
+    );
+  } catch (error) {
+    logError(requestId, "Erro ao listar missas do usuário", error);
+    return toHttpResponse(error, requestId);
+  }
+}

--- a/app/api/masses/next/route.ts
+++ b/app/api/masses/next/route.ts
@@ -1,0 +1,68 @@
+import dbConnect from "@/lib/db";
+import { requireAuth } from "@/lib/auth";
+import { getMassModel } from "@/models/Mass";
+import { getRequestId } from "@/src/server/http/request";
+import { jsonOk } from "@/src/server/http/response";
+import { toHttpResponse } from "@/src/server/http/errors";
+import { logError } from "@/src/server/http/logging";
+
+export const runtime = "nodejs";
+
+const pickByPriority = <T extends { status: string }>(items: T[], priority: string[]): T | null => {
+  for (const status of priority) {
+    const found = items.find((item) => item.status === status);
+    if (found) return found;
+  }
+  return null;
+};
+
+export async function GET(req: Request) {
+  const requestId = getRequestId(req);
+
+  try {
+    const auth = await requireAuth(req);
+    await dbConnect();
+
+    const query =
+      auth.role === "CERIMONIARIO"
+        ? {
+            status: { $in: ["SCHEDULED", "OPEN", "PREPARATION"] },
+            $or: [{ createdBy: auth.userId }, { chiefBy: auth.userId }],
+          }
+        : {
+            status: { $in: ["OPEN", "SCHEDULED"] },
+          };
+
+    const masses = await getMassModel()
+      .find(query)
+      .sort({ scheduledAt: 1 })
+      .select("_id status scheduledAt chiefBy createdBy")
+      .limit(50)
+      .lean();
+
+    const picked =
+      auth.role === "CERIMONIARIO"
+        ? pickByPriority(masses, ["OPEN", "PREPARATION", "SCHEDULED"])
+        : pickByPriority(masses, ["OPEN", "SCHEDULED"]);
+
+    if (!picked) {
+      return jsonOk({ item: null }, requestId);
+    }
+
+    return jsonOk(
+      {
+        item: {
+          id: picked._id.toString(),
+          status: picked.status,
+          scheduledAt: picked.scheduledAt,
+          chiefBy: picked.chiefBy.toString(),
+          createdBy: picked.createdBy.toString(),
+        },
+      },
+      requestId
+    );
+  } catch (error) {
+    logError(requestId, "Erro ao buscar próxima missa", error);
+    return toHttpResponse(error, requestId);
+  }
+}

--- a/app/api/signup/route.ts
+++ b/app/api/signup/route.ts
@@ -1,10 +1,17 @@
-import { NextResponse } from "next/server";
+import { ApiError, toHttpResponse } from "@/src/server/http/errors";
+import { getRequestId } from "@/src/server/http/request";
 
 export const runtime = "nodejs";
 
-export async function POST() {
-  return NextResponse.json(
-    { error: "Auto cadastro desabilitado. Solicite criação de conta a um CERIMONIARIO." },
-    { status: 403 }
+export async function POST(req: Request) {
+  const requestId = getRequestId(req);
+
+  return toHttpResponse(
+    new ApiError({
+      code: "FORBIDDEN",
+      message: "Auto cadastro desabilitado. Solicite criação de conta a um CERIMONIARIO.",
+      status: 403,
+    }),
+    requestId
   );
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -5,20 +5,40 @@ import { getAuth } from "@/lib/auth";
 
 const PUBLIC_PATH_PREFIXES = ["/_next", "/api", "/favicon.ico", "/login"];
 
+const applySecurityHeaders = (response: NextResponse) => {
+  response.headers.set("X-Content-Type-Options", "nosniff");
+  response.headers.set("Referrer-Policy", "no-referrer");
+  response.headers.set("X-Frame-Options", "DENY");
+  response.headers.set("Content-Security-Policy", "default-src 'self'; frame-ancestors 'none'; base-uri 'self';");
+};
+
 export async function middleware(req: NextRequest) {
+  const requestId = req.headers.get("x-request-id") ?? crypto.randomUUID();
+  const requestHeaders = new Headers(req.headers);
+  requestHeaders.set("x-request-id", requestId);
+
   const { pathname } = req.nextUrl;
 
   if (PUBLIC_PATH_PREFIXES.some((prefix) => pathname.startsWith(prefix))) {
-    return NextResponse.next();
+    const response = NextResponse.next({ request: { headers: requestHeaders } });
+    response.headers.set("x-request-id", requestId);
+    applySecurityHeaders(response);
+    return response;
   }
 
   const auth = await getAuth(req);
 
   if (!auth) {
-    return NextResponse.redirect(new URL("/login", req.url));
+    const response = NextResponse.redirect(new URL("/login", req.url));
+    response.headers.set("x-request-id", requestId);
+    applySecurityHeaders(response);
+    return response;
   }
 
-  return NextResponse.next();
+  const response = NextResponse.next({ request: { headers: requestHeaders } });
+  response.headers.set("x-request-id", requestId);
+  applySecurityHeaders(response);
+  return response;
 }
 
 export const config = {

--- a/src/server/http/errors.ts
+++ b/src/server/http/errors.ts
@@ -1,0 +1,119 @@
+import { NextResponse } from "next/server";
+
+import { DomainError } from "@/src/domain/mass/errors";
+
+export type ApiErrorCode =
+  | "VALIDATION_ERROR"
+  | "UNAUTHENTICATED"
+  | "FORBIDDEN"
+  | "NOT_FOUND"
+  | "CONFLICT"
+  | "RATE_LIMITED"
+  | "INTERNAL_ERROR";
+
+type ApiErrorInit = {
+  code: ApiErrorCode;
+  message: string;
+  status: number;
+  details?: unknown;
+};
+
+export class ApiError extends Error {
+  readonly code: ApiErrorCode;
+  readonly status: number;
+  readonly details?: unknown;
+
+  constructor({ code, message, status, details }: ApiErrorInit) {
+    super(message);
+    this.name = "ApiError";
+    this.code = code;
+    this.status = status;
+    this.details = details;
+  }
+}
+
+const mapDomainErrorCode = (statusCode: number): ApiErrorCode => {
+  if (statusCode === 400) return "VALIDATION_ERROR";
+  if (statusCode === 403) return "FORBIDDEN";
+  if (statusCode === 404) return "NOT_FOUND";
+  if (statusCode === 409) return "CONFLICT";
+  return "INTERNAL_ERROR";
+};
+
+export const asApiError = (error: unknown): ApiError => {
+  if (error instanceof ApiError) {
+    return error;
+  }
+
+  if (error instanceof DomainError) {
+    return new ApiError({
+      code: mapDomainErrorCode(error.statusCode),
+      message: error.message,
+      status: error.statusCode,
+    });
+  }
+
+  if (error instanceof SyntaxError) {
+    return new ApiError({
+      code: "VALIDATION_ERROR",
+      message: "JSON inválido",
+      status: 400,
+    });
+  }
+
+  if (error instanceof Error) {
+    if (error.message === "Não autorizado") {
+      return new ApiError({
+        code: "UNAUTHENTICATED",
+        message: error.message,
+        status: 401,
+      });
+    }
+
+    if (error.message === "Acesso negado") {
+      return new ApiError({
+        code: "FORBIDDEN",
+        message: error.message,
+        status: 403,
+      });
+    }
+  }
+
+  return new ApiError({
+    code: "INTERNAL_ERROR",
+    message: "Erro no servidor",
+    status: 500,
+  });
+};
+
+export const toHttpResponse = (error: unknown, requestId: string): NextResponse => {
+  const apiError = asApiError(error);
+
+  const errorBody: {
+    error: { code: ApiErrorCode; message: string; requestId: string; details?: unknown };
+  } = {
+    error: {
+      code: apiError.code,
+      message: apiError.message,
+      requestId,
+    },
+  };
+
+  if (apiError.details !== undefined) {
+    errorBody.error.details = apiError.details;
+  }
+
+  if (apiError.status === 500 && process.env.NODE_ENV !== "production" && error instanceof Error) {
+    errorBody.error.details = {
+      ...(typeof errorBody.error.details === "object" && errorBody.error.details !== null
+        ? (errorBody.error.details as object)
+        : {}),
+      reason: error.message,
+    };
+  }
+
+  return NextResponse.json(errorBody, {
+    status: apiError.status,
+    headers: { "x-request-id": requestId },
+  });
+};

--- a/src/server/http/logging.ts
+++ b/src/server/http/logging.ts
@@ -1,0 +1,17 @@
+export const logInfo = (requestId: string, message: string, context?: Record<string, unknown>) => {
+  if (context) {
+    console.info(`[${requestId}] ${message}`, context);
+    return;
+  }
+
+  console.info(`[${requestId}] ${message}`);
+};
+
+export const logError = (requestId: string, message: string, error?: unknown) => {
+  if (error) {
+    console.error(`[${requestId}] ${message}`, error);
+    return;
+  }
+
+  console.error(`[${requestId}] ${message}`);
+};

--- a/src/server/http/request.ts
+++ b/src/server/http/request.ts
@@ -1,0 +1,10 @@
+export const getRequestId = (req: Request): string => req.headers.get("x-request-id") || crypto.randomUUID();
+
+export const getClientIp = (req: Request): string => {
+  const forwardedFor = req.headers.get("x-forwarded-for");
+  if (forwardedFor) {
+    return forwardedFor.split(",")[0].trim();
+  }
+
+  return req.headers.get("x-real-ip") || "unknown";
+};

--- a/src/server/http/response.ts
+++ b/src/server/http/response.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from "next/server";
+
+export const jsonOk = <T>(data: T, requestId: string, init?: { status?: number }): NextResponse =>
+  NextResponse.json(data, {
+    status: init?.status,
+    headers: { "x-request-id": requestId },
+  });

--- a/src/server/security/rate-limit.ts
+++ b/src/server/security/rate-limit.ts
@@ -1,0 +1,33 @@
+import { ApiError } from "@/src/server/http/errors";
+
+type RateLimitRecord = {
+  count: number;
+  resetAt: number;
+};
+
+const attemptsByIp = new Map<string, RateLimitRecord>();
+
+const WINDOW_MS = 5 * 60 * 1000;
+const MAX_ATTEMPTS = 10;
+
+export const assertLoginRateLimit = (ip: string): void => {
+  const now = Date.now();
+  const current = attemptsByIp.get(ip);
+
+  if (!current || current.resetAt <= now) {
+    attemptsByIp.set(ip, { count: 1, resetAt: now + WINDOW_MS });
+    return;
+  }
+
+  if (current.count >= MAX_ATTEMPTS) {
+    throw new ApiError({
+      code: "RATE_LIMITED",
+      status: 429,
+      message: "Muitas tentativas de login. Tente novamente em alguns minutos.",
+      details: { resetAt: new Date(current.resetAt).toISOString() },
+    });
+  }
+
+  current.count += 1;
+  attemptsByIp.set(ip, current);
+};


### PR DESCRIPTION
### Motivation
- Fortalecer observabilidade e consistência das APIs adicionando correlação por request e formato de erro uniforme para facilitar operações e rastreabilidade.
- Melhorar ergonomia do CERIMONIARIO com endpoints de consulta operacionais (`/api/masses/mine` e `/api/masses/next`) para uso direto pela UI de operação.
- Aplicar hardening mínimo (rate-limit leve no login, headers de segurança) e garantir que rotas que acessam Mongo rodem em runtime Node (não Edge).

### Description
- Adicionado helper central de erros em `src/server/http/errors.ts` com `ApiError` e `toHttpResponse` para o formato padrão `{ error: { code, message, requestId, details? } }` e header `x-request-id`.
- Implementada correlação por request com `src/server/http/request.ts` (`getRequestId`, `getClientIp`) e logging correlacionado em `src/server/http/logging.ts`; resposta helper `jsonOk` em `src/server/http/response.ts` usado nas rotas.
- Adicionados endpoints operacionais de leitura: `GET /api/masses/mine` (filtros, paginação e regras por role) e `GET /api/masses/next` (priorização por status/role) em `app/api/masses/mine/route.ts` e `app/api/masses/next/route.ts`.
- Padronizei handlers existentes para usar o novo esquema de erros/logs/requestId (várias rotas em `app/api/*`, ex.: `app/api/masses`, `app/api/masses/[id]`, `app/api/*/login`, `app/api/auth/me`, `app/api/setup`, `app/api/users`, helpers de ação `app/api/masses/[id]/_action-helpers.ts`).
- Implementado rate limiter em memória `src/server/security/rate-limit.ts` (10 tentativas por IP por 5 minutos) aplicado a `POST /api/login` e `POST /api/auth/login`, retornando `429` com o mesmo formato de erro padronizado e `details.resetAt`.
- Hardening: adição de headers de segurança no `middleware.ts` (`X-Content-Type-Options`, `Referrer-Policy`, `X-Frame-Options`, `Content-Security-Policy`) e propagação de `x-request-id` sem quebrar rotas estáticas; mantive `export const runtime = "nodejs"` nas rotas que acessam DB.
- Melhorada observabilidade do fluxo de criação de missa adicionando evento `MASS_CREATED` no `events` durante `POST /api/masses`.
- Atualizado `README.md` com política “abertura de missa manual only”, exemplos de erro padrão, exemplo de 429, e roteiros de testes manuais.

### Testing
- Executado `npm run lint` e `next lint` sem avisos ou erros (✅).
- Executado `npm run build` e build do Next compilou com sucesso e rotas server incluídas (✅).
- Varredura por automações (`cron`, `setInterval`, `setTimeout`, `scheduler`, `worker`, `auto-open`) não encontrou jobs ativos e README documenta a política manual-only (✅).
- Verificações básicas de roteamento confirmaram uso do App Router (`app` presente, `pages` ausente) (✅).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b99b088c8832cbd4d320f5ada301c)