### PR TITLE
Etapa 5: UI operacional de missas + ajustes backend (massType, templates, /api/me)

### DIFF
--- a/app/api/masses/[id]/route.ts
+++ b/app/api/masses/[id]/route.ts
@@ -36,6 +36,7 @@ export async function GET(req: Request, context: RouteContext) {
       {
         id: mass._id.toString(),
         status: mass.status,
+        massType: mass.massType,
         scheduledAt: mass.scheduledAt,
         createdBy: mass.createdBy.toString(),
         chiefBy: mass.chiefBy.toString(),

--- a/app/api/masses/mine/route.ts
+++ b/app/api/masses/mine/route.ts
@@ -57,7 +57,7 @@ export async function GET(req: Request) {
     if (auth.role === "CERIMONIARIO") {
       filter.$or = [{ createdBy: auth.userId }, { chiefBy: auth.userId }];
     } else {
-      filter.$or = [{ "attendance.joined.userId": auth.userId }, { "attendance.confirmed.userId": auth.userId }];
+      filter["attendance.confirmed.userId"] = auth.userId;
     }
 
     const skip = (page - 1) * limit;
@@ -67,7 +67,7 @@ export async function GET(req: Request) {
       .sort({ scheduledAt: 1 })
       .skip(skip)
       .limit(limit)
-      .select("_id status scheduledAt chiefBy createdBy")
+      .select("_id status massType scheduledAt chiefBy createdBy")
       .lean();
 
     return jsonOk(
@@ -75,6 +75,7 @@ export async function GET(req: Request) {
         items: masses.map((mass) => ({
           id: mass._id.toString(),
           status: mass.status,
+          massType: mass.massType,
           scheduledAt: mass.scheduledAt,
           chiefBy: mass.chiefBy.toString(),
           createdBy: mass.createdBy.toString(),

--- a/app/api/masses/next/route.ts
+++ b/app/api/masses/next/route.ts
@@ -27,7 +27,6 @@ export async function GET(req: Request) {
       auth.role === "CERIMONIARIO"
         ? {
             status: { $in: ["SCHEDULED", "OPEN", "PREPARATION"] },
-            $or: [{ createdBy: auth.userId }, { chiefBy: auth.userId }],
           }
         : {
             status: { $in: ["OPEN", "SCHEDULED"] },
@@ -36,7 +35,7 @@ export async function GET(req: Request) {
     const masses = await getMassModel()
       .find(query)
       .sort({ scheduledAt: 1 })
-      .select("_id status scheduledAt chiefBy createdBy")
+      .select("_id status massType scheduledAt chiefBy createdBy")
       .limit(50)
       .lean();
 
@@ -54,6 +53,7 @@ export async function GET(req: Request) {
         item: {
           id: picked._id.toString(),
           status: picked.status,
+          massType: picked.massType,
           scheduledAt: picked.scheduledAt,
           chiefBy: picked.chiefBy.toString(),
           createdBy: picked.createdBy.toString(),

--- a/app/api/masses/role-templates/route.ts
+++ b/app/api/masses/role-templates/route.ts
@@ -1,0 +1,18 @@
+import { requireAuth } from "@/lib/auth";
+import { MASS_ROLE_TEMPLATES } from "@/src/domain/mass/role-templates";
+import { toHttpResponse } from "@/src/server/http/errors";
+import { getRequestId } from "@/src/server/http/request";
+import { jsonOk } from "@/src/server/http/response";
+
+export const runtime = "nodejs";
+
+export async function GET(req: Request) {
+  const requestId = getRequestId(req);
+
+  try {
+    await requireAuth(req);
+    return jsonOk(MASS_ROLE_TEMPLATES, requestId);
+  } catch (error) {
+    return toHttpResponse(error, requestId);
+  }
+}

--- a/app/api/me/route.ts
+++ b/app/api/me/route.ts
@@ -1,0 +1,26 @@
+import dbConnect from "@/lib/db";
+import { requireAuth } from "@/lib/auth";
+import { getUserModel } from "@/models/User";
+import { ApiError, toHttpResponse } from "@/src/server/http/errors";
+import { getRequestId } from "@/src/server/http/request";
+import { jsonOk } from "@/src/server/http/response";
+
+export const runtime = "nodejs";
+
+export async function GET(req: Request) {
+  const requestId = getRequestId(req);
+
+  try {
+    const auth = await requireAuth(req);
+    await dbConnect();
+
+    const user = await getUserModel().findById(auth.userId).select("_id role name").lean();
+    if (!user) {
+      throw new ApiError({ code: "UNAUTHENTICATED", message: "Não autorizado", status: 401 });
+    }
+
+    return jsonOk({ id: user._id.toString(), role: user.role, name: user.name }, requestId);
+  } catch (error) {
+    return toHttpResponse(error, requestId);
+  }
+}

--- a/app/masses/MassesDashboard.tsx
+++ b/app/masses/MassesDashboard.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+
+import { useMe } from "@/hooks/use-me";
+import { ApiClientError, apiFetch } from "@/lib/api";
+import { formatDateTime, statusLabel } from "@/lib/mass-ui";
+
+type MassListItem = { id: string; status: string; massType: string; scheduledAt: string; chiefBy: string; createdBy: string };
+
+type ListResponse = { items: MassListItem[] };
+type NextResponse = { item: MassListItem | null };
+
+export function MassesDashboard() {
+  const meState = useMe();
+  const router = useRouter();
+  const [error, setError] = React.useState<string | null>(null);
+
+  const [status, setStatus] = React.useState("");
+  const [from, setFrom] = React.useState("");
+  const [to, setTo] = React.useState("");
+
+  const [allMasses, setAllMasses] = React.useState<MassListItem[]>([]);
+  const [nextMass, setNextMass] = React.useState<MassListItem | null>(null);
+  const [myHistory, setMyHistory] = React.useState<MassListItem[]>([]);
+
+  const loadData = React.useCallback(async () => {
+    setError(null);
+    try {
+      if (meState.status !== "loggedIn") return;
+
+      if (meState.me.role === "CERIMONIARIO") {
+        const params = new URLSearchParams();
+        if (status) params.set("status", status);
+        if (from) params.set("from", from);
+        if (to) params.set("to", to);
+        const query = params.toString();
+        const data = await apiFetch<ListResponse>(`/api/masses${query ? `?${query}` : ""}`);
+        setAllMasses(data.items);
+        return;
+      }
+
+      const [nextData, mineData] = await Promise.all([
+        apiFetch<NextResponse>("/api/masses/next"),
+        apiFetch<ListResponse>("/api/masses/mine"),
+      ]);
+      setNextMass(nextData.item);
+      setMyHistory(mineData.items);
+    } catch (e) {
+      if (e instanceof ApiClientError && e.status === 401) {
+        router.replace("/login");
+        return;
+      }
+      setError(e instanceof Error ? e.message : "Erro ao carregar missas");
+    }
+  }, [from, meState, router, status, to]);
+
+  React.useEffect(() => {
+    void loadData();
+  }, [loadData]);
+
+  if (meState.status === "loading") {
+    return <main className="p-8">Carregando...</main>;
+  }
+
+  if (meState.status === "loggedOut") {
+    router.replace("/login");
+    return null;
+  }
+
+  return (
+    <main className="min-h-screen p-8 space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">Missas</h1>
+        {meState.me.role === "CERIMONIARIO" && (
+          <Link className="underline" href="/masses/new">
+            Nova missa
+          </Link>
+        )}
+      </div>
+
+      {error && <p className="text-sm text-destructive">{error}</p>}
+
+      {meState.me.role === "CERIMONIARIO" ? (
+        <section className="space-y-3">
+          <h2 className="text-lg font-medium">Todas as missas</h2>
+          <div className="flex gap-2 flex-wrap">
+            <select className="border p-2" value={status} onChange={(event) => setStatus(event.target.value)}>
+              <option value="">Todos status</option>
+              <option value="SCHEDULED">SCHEDULED</option>
+              <option value="OPEN">OPEN</option>
+              <option value="PREPARATION">PREPARATION</option>
+              <option value="FINISHED">FINISHED</option>
+              <option value="CANCELED">CANCELED</option>
+            </select>
+            <input className="border p-2" type="datetime-local" value={from} onChange={(event) => setFrom(event.target.value)} />
+            <input className="border p-2" type="datetime-local" value={to} onChange={(event) => setTo(event.target.value)} />
+            <button className="border px-3" onClick={() => void loadData()} type="button">
+              Filtrar
+            </button>
+          </div>
+          <MassList items={allMasses} />
+        </section>
+      ) : (
+        <>
+          <section className="space-y-3">
+            <h2 className="text-lg font-medium">Próxima missa</h2>
+            <MassList items={nextMass ? [nextMass] : []} emptyText="Nenhuma missa disponível" />
+          </section>
+          <section className="space-y-3">
+            <h2 className="text-lg font-medium">Meu histórico (confirmadas)</h2>
+            <MassList items={myHistory} emptyText="Você ainda não confirmou presença em missas" />
+          </section>
+        </>
+      )}
+    </main>
+  );
+}
+
+function MassList({ items, emptyText = "Sem missas" }: { items: MassListItem[]; emptyText?: string }) {
+  if (items.length === 0) {
+    return <p className="text-sm text-muted-foreground">{emptyText}</p>;
+  }
+
+  return (
+    <ul className="space-y-2">
+      {items.map((item) => (
+        <li key={item.id} className="border rounded p-3">
+          <p>{formatDateTime(item.scheduledAt)}</p>
+          <p>Status: {statusLabel[item.status] ?? item.status}</p>
+          <p>Tipo: {item.massType}</p>
+          <Link className="underline" href={`/masses/${item.id}`}>
+            Ver detalhe
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/app/masses/[id]/MassDetail.tsx
+++ b/app/masses/[id]/MassDetail.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+
+import { useMe } from "@/hooks/use-me";
+import { ApiClientError, apiFetch } from "@/lib/api";
+import { formatDateTime, statusLabel } from "@/lib/mass-ui";
+
+type Entry = { userId: string; joinedAt?: string; confirmedAt?: string };
+type Assignment = { roleKey: string; userId: string | null };
+type Event = { type: string; actorId: string; at: string };
+
+type MassDetailResponse = {
+  id: string;
+  status: string;
+  massType: "SIMPLES" | "SOLENE" | "PALAVRA";
+  scheduledAt: string;
+  chiefBy: string;
+  createdBy: string;
+  attendance: { joined: Entry[]; confirmed: Entry[] };
+  assignments: Assignment[];
+  events: Event[];
+};
+
+type TemplateResponse = Record<"SIMPLES" | "SOLENE" | "PALAVRA", string[]>;
+type UserResponse = { items: { id: string; name: string }[] };
+
+export function MassDetail({ id }: { id: string }) {
+  const router = useRouter();
+  const meState = useMe();
+  const [mass, setMass] = React.useState<MassDetailResponse | null>(null);
+  const [templates, setTemplates] = React.useState<TemplateResponse | null>(null);
+  const [users, setUsers] = React.useState<{ id: string; name: string }[]>([]);
+  const [draftAssignments, setDraftAssignments] = React.useState<Assignment[]>([]);
+  const [delegateTo, setDelegateTo] = React.useState("");
+  const [error, setError] = React.useState<string | null>(null);
+
+  const load = React.useCallback(async () => {
+    setError(null);
+    try {
+      const massData = await apiFetch<MassDetailResponse>(`/api/masses/${id}`);
+      setMass(massData);
+
+      if (massData.status === "PREPARATION") {
+        const [templateData, usersData] = await Promise.all([
+          apiFetch<TemplateResponse>("/api/masses/role-templates"),
+          apiFetch<UserResponse>("/api/users?role=ACOLITO&active=true"),
+        ]);
+        setTemplates(templateData);
+        setUsers(usersData.items);
+        setDraftAssignments(massData.assignments);
+      }
+    } catch (e) {
+      if (e instanceof ApiClientError && e.status === 401) {
+        router.replace("/login");
+        return;
+      }
+      setError(e instanceof Error ? e.message : "Erro ao carregar missa");
+    }
+  }, [id, router]);
+
+  React.useEffect(() => {
+    void load();
+  }, [load]);
+
+  const callAction = async (path: string, body?: unknown) => {
+    try {
+      await apiFetch<{ ok: boolean }>(path, { method: "POST", body: JSON.stringify(body ?? {}) });
+      await load();
+    } catch (e) {
+      if (e instanceof ApiClientError && e.status === 401) {
+        router.replace("/login");
+        return;
+      }
+      setError(e instanceof Error ? e.message : "Erro de ação");
+    }
+  };
+
+  if (meState.status === "loading" || !mass) return <main className="p-8">Carregando...</main>;
+  if (meState.status === "loggedOut") return null;
+
+  const isAdmin = meState.me.role === "CERIMONIARIO";
+  const isCreator = mass.createdBy === meState.me.id;
+  const canAdminThisMass = isAdmin && (isCreator || mass.chiefBy === meState.me.id);
+  const hasConfirmed = mass.attendance.confirmed.some((entry) => entry.userId === meState.me.id);
+
+  const templateRoles = templates?.[mass.massType] ?? [];
+  const fixedRoles = templateRoles.filter((role) => role !== "NONE");
+  const noneAssignments = draftAssignments.filter((entry) => entry.roleKey === "NONE");
+
+  return (
+    <main className="p-8 space-y-4">
+      <h1 className="text-2xl font-semibold">Detalhe da missa</h1>
+      {error && <p className="text-sm text-destructive">{error}</p>}
+
+      <p>Data: {formatDateTime(mass.scheduledAt)}</p>
+      <p>Status: {statusLabel[mass.status] ?? mass.status}</p>
+      <p>Tipo: {mass.massType}</p>
+      <p>createdBy: {mass.createdBy}</p>
+      <p>chiefBy: {mass.chiefBy}</p>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        <div className="border p-3">
+          <h2 className="font-medium">Joined ({mass.attendance.joined.length})</h2>
+          <ul>{mass.attendance.joined.map((entry) => <li key={entry.userId}>{entry.userId}</li>)}</ul>
+        </div>
+        <div className="border p-3">
+          <h2 className="font-medium">Confirmed ({mass.attendance.confirmed.length})</h2>
+          <ul>{mass.attendance.confirmed.map((entry) => <li key={entry.userId}>{entry.userId}</li>)}</ul>
+        </div>
+      </div>
+
+      <div className="space-x-2">
+        {canAdminThisMass && mass.status === "SCHEDULED" && (
+          <>
+            <button className="border px-3 py-1" onClick={() => void callAction(`/api/masses/${id}/open`)} type="button">OPEN</button>
+            <button className="border px-3 py-1" onClick={() => void callAction(`/api/masses/${id}/cancel`)} type="button">CANCEL</button>
+          </>
+        )}
+        {canAdminThisMass && mass.status === "OPEN" && (
+          <>
+            <button className="border px-3 py-1" onClick={() => void callAction(`/api/masses/${id}/preparation`)} type="button">PREPARATION</button>
+            <button className="border px-3 py-1" onClick={() => void callAction(`/api/masses/${id}/cancel`)} type="button">CANCEL</button>
+          </>
+        )}
+        {canAdminThisMass && mass.status === "PREPARATION" && (
+          <button className="border px-3 py-1" onClick={() => void callAction(`/api/masses/${id}/finish`)} type="button">FINISH</button>
+        )}
+
+        {!isAdmin && mass.status === "OPEN" && !hasConfirmed && (
+          <>
+            <button className="border px-3 py-1" onClick={() => void callAction(`/api/masses/${id}/join`)} type="button">JOIN</button>
+            <button className="border px-3 py-1" onClick={() => void callAction(`/api/masses/${id}/confirm`)} type="button">CONFIRM</button>
+          </>
+        )}
+        {!isAdmin && hasConfirmed && <span>Confirmado ✅</span>}
+      </div>
+
+      {isCreator && (
+        <div className="space-y-2 border p-3">
+          <h2 className="font-medium">Delegar chief</h2>
+          <input className="border p-2" placeholder="ID do novo chief" value={delegateTo} onChange={(e) => setDelegateTo(e.target.value)} />
+          <button className="border px-3 py-1" type="button" onClick={() => void callAction(`/api/masses/${id}/delegate`, { newChiefBy: delegateTo })}>DELEGATE</button>
+        </div>
+      )}
+
+      <div className="border p-3 space-y-2">
+        <h2 className="font-medium">Assignments</h2>
+        {mass.status === "PREPARATION" && canAdminThisMass && templates ? (
+          <>
+            {fixedRoles.map((roleKey) => {
+              const current = draftAssignments.find((entry) => entry.roleKey === roleKey) ?? { roleKey, userId: null };
+              return (
+                <AssignmentRow
+                  key={roleKey}
+                  roleKey={roleKey}
+                  value={current.userId}
+                  users={users}
+                  onChange={(userId) => {
+                    setDraftAssignments((prev) => {
+                      const next = prev.filter((entry) => entry.roleKey !== roleKey);
+                      next.push({ roleKey, userId });
+                      return next;
+                    });
+                  }}
+                />
+              );
+            })}
+
+            {noneAssignments.map((entry, index) => (
+              <AssignmentRow
+                key={`NONE-${index}`}
+                roleKey="NONE"
+                value={entry.userId}
+                users={users}
+                onChange={(userId) => {
+                  setDraftAssignments((prev) => prev.map((item, itemIndex) => (itemIndex === index ? { ...item, userId } : item)));
+                }}
+              />
+            ))}
+
+            <button className="border px-3 py-1" type="button" onClick={() => setDraftAssignments((prev) => [...prev, { roleKey: "NONE", userId: null }])}>
+              Adicionar NONE
+            </button>
+
+            <button className="border px-3 py-1" type="button" onClick={() => void callAction(`/api/masses/${id}/assign-roles`, { assignments: draftAssignments })}>
+              ASSIGN ROLES
+            </button>
+          </>
+        ) : (
+          <ul className="list-disc ml-5">
+            {mass.assignments.map((item, index) => (
+              <li key={`${item.roleKey}-${index}`}>
+                {item.roleKey}: {item.userId ?? "(vago)"}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <div className="border p-3">
+        <h2 className="font-medium">Últimos eventos</h2>
+        <ul className="list-disc ml-5">
+          {mass.events.slice(-10).reverse().map((event, index) => (
+            <li key={`${event.type}-${index}`}>
+              {event.type} por {event.actorId} em {formatDateTime(event.at)}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </main>
+  );
+}
+
+function AssignmentRow({
+  roleKey,
+  value,
+  users,
+  onChange,
+}: {
+  roleKey: string;
+  value: string | null;
+  users: { id: string; name: string }[];
+  onChange: (userId: string | null) => void;
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="w-56">{roleKey}</span>
+      <select className="border p-2" value={value ?? ""} onChange={(event) => onChange(event.target.value || null)}>
+        <option value="">(vago)</option>
+        {users.map((user) => (
+          <option key={user.id} value={user.id}>
+            {user.name}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/app/masses/[id]/page.tsx
+++ b/app/masses/[id]/page.tsx
@@ -1,0 +1,15 @@
+import { redirect } from "next/navigation";
+
+import { getAuth } from "@/lib/auth";
+
+import { MassDetail } from "./MassDetail";
+
+type PageProps = { params: Promise<{ id: string }> };
+
+export default async function MassDetailPage({ params }: PageProps) {
+  const auth = await getAuth();
+  if (!auth) redirect("/login");
+
+  const { id } = await params;
+  return <MassDetail id={id} />;
+}

--- a/app/masses/new/NewMassForm.tsx
+++ b/app/masses/new/NewMassForm.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+
+import { ApiClientError, apiFetch } from "@/lib/api";
+
+export function NewMassForm() {
+  const router = useRouter();
+  const [scheduledAt, setScheduledAt] = React.useState("");
+  const [massType, setMassType] = React.useState("SIMPLES");
+  const [error, setError] = React.useState<string | null>(null);
+
+  const onSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setError(null);
+
+    try {
+      const data = await apiFetch<{ massId: string }>("/api/masses", {
+        method: "POST",
+        body: JSON.stringify({ scheduledAt, massType }),
+      });
+      router.replace(`/masses/${data.massId}`);
+    } catch (e) {
+      if (e instanceof ApiClientError && e.status === 401) {
+        router.replace("/login");
+        return;
+      }
+      setError(e instanceof Error ? e.message : "Erro ao criar missa");
+    }
+  };
+
+  return (
+    <main className="p-8">
+      <h1 className="text-2xl font-semibold mb-4">Nova missa</h1>
+      <form onSubmit={onSubmit} className="space-y-3 max-w-md">
+        <input className="border p-2 w-full" type="datetime-local" value={scheduledAt} onChange={(event) => setScheduledAt(event.target.value)} required />
+        <select className="border p-2 w-full" value={massType} onChange={(event) => setMassType(event.target.value)}>
+          <option value="SIMPLES">SIMPLES</option>
+          <option value="SOLENE">SOLENE</option>
+          <option value="PALAVRA">PALAVRA</option>
+        </select>
+        <button className="border px-3 py-2" type="submit">
+          Criar
+        </button>
+      </form>
+      {error && <p className="text-sm text-destructive mt-3">{error}</p>}
+    </main>
+  );
+}

--- a/app/masses/new/page.tsx
+++ b/app/masses/new/page.tsx
@@ -1,0 +1,13 @@
+import { redirect } from "next/navigation";
+
+import { getAuth } from "@/lib/auth";
+
+import { NewMassForm } from "./NewMassForm";
+
+export default async function NewMassPage() {
+  const auth = await getAuth();
+  if (!auth) redirect("/login");
+  if (auth.role !== "CERIMONIARIO") redirect("/masses");
+
+  return <NewMassForm />;
+}

--- a/app/masses/page.tsx
+++ b/app/masses/page.tsx
@@ -2,18 +2,13 @@ import { redirect } from "next/navigation";
 
 import { getAuth } from "@/lib/auth";
 
+import { MassesDashboard } from "./MassesDashboard";
+
 export default async function MassesPage() {
   const auth = await getAuth();
-
   if (!auth) {
     redirect("/login");
   }
 
-  return (
-    <main className="min-h-screen p-8 font-[family-name:var(--font-geist-sans)]">
-      <h1 className="text-2xl font-semibold">Tela inicial</h1>
-      <p className="mt-2">Usuário autenticado com sucesso.</p>
-      <p className="mt-1">Perfil: {auth.role}</p>
-    </main>
-  );
+  return <MassesDashboard />;
 }

--- a/hooks/use-me.ts
+++ b/hooks/use-me.ts
@@ -1,0 +1,41 @@
+"use client";
+
+import * as React from "react";
+
+import { ApiClientError, apiFetch } from "@/lib/api";
+
+type MeResponse = { id: string; role: "CERIMONIARIO" | "ACOLITO"; name: string };
+
+type UseMeResult =
+  | { status: "loading"; me: null; error: null }
+  | { status: "loggedOut"; me: null; error: ApiClientError | null }
+  | { status: "loggedIn"; me: MeResponse; error: null };
+
+export function useMe(): UseMeResult {
+  const [state, setState] = React.useState<UseMeResult>({ status: "loading", me: null, error: null });
+
+  React.useEffect(() => {
+    let active = true;
+
+    apiFetch<MeResponse>("/api/me")
+      .then((me) => {
+        if (!active) return;
+        setState({ status: "loggedIn", me, error: null });
+      })
+      .catch((error: unknown) => {
+        if (!active) return;
+        if (error instanceof ApiClientError && error.status === 401) {
+          setState({ status: "loggedOut", me: null, error });
+          return;
+        }
+
+        setState({ status: "loggedOut", me: null, error: error as ApiClientError });
+      });
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return state;
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,0 +1,47 @@
+export type ApiErrorShape = {
+  error?: {
+    code?: string;
+    message?: string;
+    requestId?: string;
+    details?: unknown;
+  };
+};
+
+export class ApiClientError extends Error {
+  status: number;
+  code?: string;
+
+  constructor(status: number, message: string, code?: string) {
+    super(message);
+    this.status = status;
+    this.code = code;
+  }
+}
+
+const fallbackMessageByStatus: Record<number, string> = {
+  401: "Sessão expirou, faça login novamente.",
+  403: "Você não tem permissão para essa ação.",
+  404: "Missa não encontrada.",
+  409: "Ação inválida para o estado atual da missa.",
+};
+
+export const toFriendlyMessage = (status: number, fallback: string) => fallbackMessageByStatus[status] ?? fallback;
+
+export async function apiFetch<T>(input: RequestInfo | URL, init?: RequestInit): Promise<T> {
+  const response = await fetch(input, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(init?.headers ?? {}),
+    },
+  });
+
+  const data = (await response.json().catch(() => ({}))) as T & ApiErrorShape;
+
+  if (!response.ok) {
+    const message = toFriendlyMessage(response.status, data.error?.message ?? "Erro ao processar requisição");
+    throw new ApiClientError(response.status, message, data.error?.code);
+  }
+
+  return data;
+}

--- a/lib/mass-ui.ts
+++ b/lib/mass-ui.ts
@@ -1,0 +1,10 @@
+export const statusLabel: Record<string, string> = {
+  SCHEDULED: "Agendada",
+  OPEN: "Aberta",
+  PREPARATION: "Preparação",
+  FINISHED: "Finalizada",
+  CANCELED: "Cancelada",
+};
+
+export const formatDateTime = (value: string | Date) =>
+  new Intl.DateTimeFormat("pt-BR", { dateStyle: "short", timeStyle: "short" }).format(new Date(value));

--- a/models/Mass.ts
+++ b/models/Mass.ts
@@ -4,6 +4,8 @@ import { getMongoose } from "@/lib/mongoose";
 
 export const MASS_STATUSES = ["SCHEDULED", "OPEN", "PREPARATION", "FINISHED", "CANCELED"] as const;
 export type MassStatus = (typeof MASS_STATUSES)[number];
+export const MASS_TYPES = ["SIMPLES", "SOLENE", "PALAVRA"] as const;
+export type MassType = (typeof MASS_TYPES)[number];
 
 export type AttendanceEntry = {
   userId: Types.ObjectId;
@@ -26,6 +28,7 @@ export type EventEntry = {
 export type MassDocument = {
   _id: Types.ObjectId;
   status: MassStatus;
+  massType: MassType;
   scheduledAt: Date;
   createdBy: Types.ObjectId;
   chiefBy: Types.ObjectId;
@@ -86,6 +89,11 @@ const buildMassSchema = (mongoose: ReturnType<typeof getMongoose>) => {
         type: String,
         enum: MASS_STATUSES,
         default: "SCHEDULED",
+        required: true,
+      },
+      massType: {
+        type: String,
+        enum: MASS_TYPES,
         required: true,
       },
       scheduledAt: { type: Date, required: true },

--- a/src/domain/mass/role-templates.ts
+++ b/src/domain/mass/role-templates.ts
@@ -1,0 +1,21 @@
+import type { MassType } from "@/models/Mass";
+
+export const MASS_ROLE_TEMPLATES: Record<MassType, string[]> = {
+  SIMPLES: ["MISSAL", "CREDENCIA", "AMBAO", "SINO_1", "ACOMPANHANTE_DO_LEITOR", "TOCHA_1", "TOCHA_2", "NONE"],
+  SOLENE: [
+    "TURIFERARIO",
+    "MISSAL",
+    "CREDENCIA",
+    "AMBAO",
+    "SINO_1",
+    "ACOMPANHANTE_DO_LEITOR",
+    "SINO_2",
+    "TOCHA_1",
+    "TOCHA_2",
+    "NONE",
+  ],
+  PALAVRA: ["CREDENCIA", "AMBAO", "ACOMPANHANTE_DO_LEITOR", "NONE"],
+};
+
+export const getAssignmentsTemplateByMassType = (massType: MassType) =>
+  MASS_ROLE_TEMPLATES[massType].map((roleKey) => ({ roleKey, userId: null }));

--- a/src/domain/mass/serializers.ts
+++ b/src/domain/mass/serializers.ts
@@ -3,6 +3,7 @@ import type { MassDocument } from "@/models/Mass";
 export const serializeMass = (mass: MassDocument) => ({
   id: mass._id.toString(),
   status: mass.status,
+  massType: mass.massType,
   scheduledAt: mass.scheduledAt,
   createdBy: mass.createdBy.toString(),
   chiefBy: mass.chiefBy.toString(),

--- a/src/domain/mass/types.ts
+++ b/src/domain/mass/types.ts
@@ -29,4 +29,3 @@ export type EventInput = {
   payload?: EventPayload;
 };
 
-export const DEFAULT_ROLE_KEYS = ["CRUCIFERARIO", "TURIFERARIO", "NAVETEIRO", "LIVRO", "MICROFONE"] as const;


### PR DESCRIPTION
### Motivation
- Implementar a UI operacional completa para gerir missas conforme as regras de produto (rota inicial `/masses`, visibilidade por `role`, fluxos de presença e preparação). 
- Suportar templates de funções por `massType` e permitir múltiplos slots `NONE` sem normalização, exigindo ajustes mínimos no backend para manter a regra de negócio no servidor.
- Expor informações de sessão para o frontend via `GET /api/me` e fornecer um cliente HTTP com mensagens de erro amigáveis para UX consistente.

### Description
- Backend: adicionado `massType` (`"SIMPLES" | "SOLENE" | "PALAVRA"`) ao schema `Mass` e passado por `POST /api/masses` e por todas as `GET` relevantes (`/api/masses`, `/api/masses/:id`, `/api/masses/next`, `/api/masses/mine`).
- Backend: criado `GET /api/me` que retorna `{ id, role, name }`, criado `GET /api/masses/role-templates` como fonte única de templates e adicionada `GET /api/users` com filtros (`role`/`active`) para popular seletores de acólitos.
- Backend: visibilidade ajustada conforme produto (ex.: `GET /api/masses` passou a exigir `CERIMONIARIO`), `next`/`mine` adaptados a prioridade/filtragem por papel, e `finish` usa template por `massType` quando não há assignments já presentes.
- Frontend: adicionados `lib/api.ts` (client + mensagens amigáveis), `hooks/use-me.ts` (estado `loading|loggedOut|loggedIn` via `GET /api/me`), utilitários UI (`lib/mass-ui.ts`), e páginas/componentes operacionais em `app/masses` incluindo dashboard (`/masses`), criação (`/masses/new`) e detalhe/edição (`/masses/[id]`) com editor de assignments que usa `GET /api/masses/role-templates` e permite múltiplos `NONE`.
- Integração: reutilizei helpers existentes (`getAuth`/`requireAuth`/`requireCerimoniario`, db singleton e shape de erro) mantendo a lógica de regras no backend e deixando o frontend como consumidor apenas.

### Testing
- Executado `npm run lint` e não houve avisos ou erros (sucesso). 
- Executado `npm run build` e a build completou com sucesso (páginas/rotas geradas). 
- Levantei o servidor em modo dev e capturei um screenshot da tela de `GET /login` via Playwright para validar UI estática (script navegou até `/login` e gerou artefato).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ba0a438f4832c85d2d6845f76b26f)